### PR TITLE
Prevent collisions with the paths of other routes

### DIFF
--- a/src/Resources/config/shop_routing.yaml
+++ b/src/Resources/config/shop_routing.yaml
@@ -1,5 +1,5 @@
 setono_sylius_terms_show:
-    path: /{slug}
+    path: /terms/{slug}
     methods: [GET]
     defaults:
         _controller: setono_sylius_terms.controller.terms:showAction
@@ -12,7 +12,7 @@ setono_sylius_terms_show:
                     - $slug
 
 setono_sylius_terms_partial_show:
-    path: /{slug}/partial
+    path: /terms/{slug}/partial
     methods: [GET]
     defaults:
         _controller: setono_sylius_terms.controller.terms:showAction


### PR DESCRIPTION
After installing the plugin, when using the `debug:router` command to check what routes the plugin adds, I see the following:
```
setono_sylius_terms_show                                       GET              ANY      ANY    /{_locale}/{slug}                                                                                               
  setono_sylius_terms_partial_show                               GET              ANY      ANY    /{_locale}/{slug}/partial
```
Considering that the route for the cart for example looks like:
```
sylius_shop_cart_summary                                       GET              ANY      ANY    /{_locale}/cart/
```
Then `cart` is interpreted as the slug for the terms and conditions. This change makes the route path look like:
```
setono_sylius_terms_show                                       GET              ANY      ANY    /{_locale}/terms/{slug}
```           