### PR TITLE
Use newer syntax in routing "templates" attribute

### DIFF
--- a/src/Resources/config/admin_routing.yaml
+++ b/src/Resources/config/admin_routing.yaml
@@ -2,7 +2,7 @@ setono_sylius_terms_admin_terms:
     resource: |
         alias: setono_sylius_terms.terms
         section: admin
-        templates: SyliusAdminBundle:Crud
+        templates: "@SyliusAdmin/Crud"
         redirect: update
         grid: setono_sylius_terms_terms
         vars:


### PR DESCRIPTION
To make it work with the newest Sylius (1.9) version 🚀 