### PR TITLE
Update JS path in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Override the [Sylius Form](https://github.com/Sylius/Sylius/blob/master/src/Syli
     
     {% block javascripts %}
         // We expect jquery to be loaded here
-        {% include '@SyliusUi/_javascripts.html.twig' with {'path': 'assets/shop/js/app.js'} %}
+        {% include '@SyliusUi/_javascripts.html.twig' with {'path': 'build/shop/shop-entry.js'} %}
     
         // But if you have it as separate script - just make sure
         // it placed before `sylius.shop.layout.javascripts` sonata block


### PR DESCRIPTION
I had some trouble following the steps in the docs to find the "right" js file to include. Not sure if something's odd in my setup (I am a fairly new Sylius user) or if some change happened in a recent version of Sylius. Anyway, I updated the URL according to my findings.
