### PR TITLE
Fix infinite loop in validation group collector

### DIFF
--- a/src/Form/Type/TermsCheckboxCollectionType.php
+++ b/src/Form/Type/TermsCheckboxCollectionType.php
@@ -32,11 +32,11 @@ final class TermsCheckboxCollectionType extends AbstractType
             $validationGroups = [];
             while (null !== $parent) {
                 $groups = $parent->getConfig()->getOption('validation_groups');
-                if (!is_array($groups)) {
-                    continue;
+
+                if (is_array($groups)) {
+		    $validationGroups[] = $groups;
                 }
 
-                $validationGroups[] = $groups;
                 $parent = $parent->getParent();
             }
 

--- a/src/Form/Type/TermsCheckboxCollectionType.php
+++ b/src/Form/Type/TermsCheckboxCollectionType.php
@@ -34,7 +34,7 @@ final class TermsCheckboxCollectionType extends AbstractType
                 $groups = $parent->getConfig()->getOption('validation_groups');
 
                 if (is_array($groups)) {
-		    $validationGroups[] = $groups;
+		            $validationGroups[] = $groups;
                 }
 
                 $parent = $parent->getParent();


### PR DESCRIPTION
If no validation groups are set on a form then validation group collection code gets stuck in an infinite loop.
This pull request modifies the while loop so it no longer hangs.